### PR TITLE
Bugfix: Accept negative spamspore and basescore

### DIFF
--- a/spamc.go
+++ b/spamc.go
@@ -133,7 +133,7 @@ func (s *Client) call(
 
 var (
 	reParseResponse = regexp.MustCompile(`(?i)SPAMD\/([0-9\.\-]+)\s([0-9]+)\s([0-9A-Z_]+)`)
-	reFindScore     = regexp.MustCompile(`(?i)Spam:\s(True|False|Yes|No)\s;\s([0-9\.]+)\s\/\s([0-9\.]+)`)
+	reFindScore     = regexp.MustCompile(`(?i)Spam:\s(True|False|Yes|No)\s;\s(-?[0-9\.]+)\s\/\s(-?[0-9\.]+)`)
 )
 
 // SpamD reply processor


### PR DESCRIPTION
When scanning a string you can get a negative score, this pull fixes a negative spamscore and can handle a negative basescore.

Returned by Spamassassin: Spam: False ; -1.5 / 5.0