### PR TITLE
[BugFix] content-length

### DIFF
--- a/sa_test.go
+++ b/sa_test.go
@@ -83,7 +83,7 @@ func TestSALearn(t *testing.T) {
 
 func TestSACheck(t *testing.T) {
 	client := New(addr, 0)
-	r, err := client.Check(context.Background(), "Penis viagra", nil)
+	r, err := client.Check(context.Background(), "\r\nPenis viagra\r\n", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestSASymbols(t *testing.T) {
 		"From: a@example.com\r\n"+
 		"Subject: Hello\r\n"+
 		"Message-ID: <serverfoo2131645635@example.com>\r\n"+
-		"\r\n\r\nthe body"+
+		"\r\n\r\nthe body\r\n"+
 		"", nil)
 	if err != nil {
 		t.Fatal(err)

--- a/sa_test.go
+++ b/sa_test.go
@@ -81,6 +81,26 @@ func TestSALearn(t *testing.T) {
 	}
 }
 
+func TestSANoTrailingNewline(t *testing.T) {
+	client := New(addr, 0)
+
+	r, err := client.Check(context.Background(), "woot", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r == nil {
+		t.Fatal("r is nil")
+	}
+
+	r, err = client.Check(context.Background(), "Subject: woot\r\n\r\nwoot", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r == nil {
+		t.Fatal("r is nil")
+	}
+}
+
 func TestSACheck(t *testing.T) {
 	client := New(addr, 0)
 	r, err := client.Check(context.Background(), "\r\nPenis viagra\r\n", nil)

--- a/spamc.go
+++ b/spamc.go
@@ -98,6 +98,12 @@ func (c *Client) write(
 		return err
 	}
 
+	// Make the sure message always ends in \r\n, if it doesn't SA will just
+	// keep reading from the connection and it will block until it timouts.
+	if !strings.HasSuffix(message, "\r\n") {
+		message += "\r\n"
+	}
+
 	// Always add Content-length header.
 	err = tp.PrintfLine("Content-length: %v", len(message))
 	if err != nil {

--- a/spamc.go
+++ b/spamc.go
@@ -99,8 +99,7 @@ func (c *Client) write(
 	}
 
 	// Always add Content-length header.
-	// TODO: Is the +2 always required?
-	err = tp.PrintfLine("Content-length: %v", len(message)+2)
+	err = tp.PrintfLine("Content-length: %v", len(message))
 	if err != nil {
 		return err
 	}
@@ -120,7 +119,7 @@ func (c *Client) write(
 	}
 
 	// Write body.
-	_, err = tp.W.WriteString(strings.TrimSpace(message) + "\r\n\r\n")
+	_, err = tp.W.WriteString(message)
 	if err != nil {
 		return err
 	}

--- a/spamc_test.go
+++ b/spamc_test.go
@@ -21,16 +21,16 @@ func TestWrite(t *testing.T) {
 	}{
 		{
 			"CMD", "Message", Header{HeaderUser: []string{"xx"}},
-			"CMD SPAMC/1.5\r\nContent-length: 7\r\nUser: xx\r\n\r\nMessage",
+			"CMD SPAMC/1.5\r\nContent-length: 9\r\nUser: xx\r\n\r\nMessage\r\n",
 			"",
 		},
 		{
 			"CMD", "Message", nil,
-			"CMD SPAMC/1.5\r\nContent-length: 7\r\n\r\nMessage",
+			"CMD SPAMC/1.5\r\nContent-length: 9\r\n\r\nMessage\r\n",
 			"",
 		},
 		{"", "Message", nil, "", "empty command"},
-		{"CMD", "", nil, "CMD SPAMC/1.5\r\nContent-length: 0\r\n\r\n", ""},
+		{"CMD", "", nil, "CMD SPAMC/1.5\r\nContent-length: 2\r\n\r\n\r\n", ""},
 	}
 
 	for i, tc := range cases {

--- a/spamc_test.go
+++ b/spamc_test.go
@@ -21,16 +21,16 @@ func TestWrite(t *testing.T) {
 	}{
 		{
 			"CMD", "Message", Header{HeaderUser: []string{"xx"}},
-			"CMD SPAMC/1.5\r\nContent-length: 9\r\nUser: xx\r\n\r\nMessage\r\n\r\n",
+			"CMD SPAMC/1.5\r\nContent-length: 7\r\nUser: xx\r\n\r\nMessage",
 			"",
 		},
 		{
 			"CMD", "Message", nil,
-			"CMD SPAMC/1.5\r\nContent-length: 9\r\n\r\nMessage\r\n\r\n",
+			"CMD SPAMC/1.5\r\nContent-length: 7\r\n\r\nMessage",
 			"",
 		},
 		{"", "Message", nil, "", "empty command"},
-		{"CMD", "", nil, "CMD SPAMC/1.5\r\nContent-length: 2\r\n\r\n\r\n\r\n", ""},
+		{"CMD", "", nil, "CMD SPAMC/1.5\r\nContent-length: 0\r\n\r\n", ""},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
- Remove trimming the message it mutates what the user sent (and could add to spam score)
- Remove the extra content for the message, this means we can also remove the +2