### PR TITLE
Remove SKIP command

### DIFF
--- a/api.go
+++ b/api.go
@@ -16,7 +16,6 @@ const (
 	CmdSymbols      = "SYMBOLS"
 	CmdReport       = "REPORT"
 	CmdReportIfspam = "REPORT_IFSPAM"
-	CmdSkip         = "SKIP"
 	CmdPing         = "PING"
 	CmdTell         = "TELL"
 	CmdProcess      = "PROCESS"
@@ -190,15 +189,6 @@ func (c *Client) ReportIfSpam(
 	headers Header,
 ) (*Response, error) {
 	return c.simpleCall(CmdReportIfspam, msg, headers)
-}
-
-// Skip ignores this message: client opened connection then changed its mind.
-func (c *Client) Skip(
-	ctx context.Context,
-	msg string,
-	headers Header,
-) (*Response, error) {
-	return c.simpleCall(CmdSkip, msg, headers)
 }
 
 // Process this message and return a modified message.

--- a/old.go
+++ b/old.go
@@ -50,12 +50,7 @@ func processResponse(cmd string, read io.Reader) (*Response, error) {
 
 	var result = reParseResponse.FindStringSubmatch(lineStr)
 	if len(result) < 4 {
-		if cmd != "SKIP" {
-			return nil, fmt.Errorf("spamd unrecognised reply: %v", lineStr)
-		}
-		return &Response{
-			Message: "SKIPPED",
-		}, nil
+		return nil, fmt.Errorf("spamd unrecognised reply: %v", lineStr)
 	}
 
 	returnCode, err := strconv.Atoi(result[2])

--- a/sa_test.go
+++ b/sa_test.go
@@ -22,7 +22,6 @@ func TestSACommands(t *testing.T) {
 		fun  func(context.Context, string, Header) (*Response, error)
 	}{
 		//{"Check", client.Check},
-		{"Skip", client.Skip},
 		//{"Symbols", client.Symbols},
 		{"Report", client.Report},
 		{"ReportIfSpam", client.ReportIfSpam},


### PR DESCRIPTION
This command is to tell SA to "skip" this connection, it's for when the
"client opened connection then changed its mind".

It doesn't make sense for us to have this, since there is never a case
where we open a connection and then "change our mind" since we don't
dial the SA server until we call a command.

Maybe this will change in the future, in which case we can add it again,
but for now let's just remove it.