### PR TITLE
Fix Report.String() for long rule names

### DIFF
--- a/spamc.go
+++ b/spamc.go
@@ -359,7 +359,12 @@ func (r Report) String() string {
 		}
 
 		line := fmt.Sprintf("%v%.1f %v", leadingSpace, t.Points, t.Rule)
-		line += strings.Repeat(" ", 28-len(line)) + t.Description + "\n"
+		nspaces := 27 - len(line)
+		spaces := " "
+		if nspaces > 0 {
+			spaces += strings.Repeat(" ", nspaces)
+		}
+		line += spaces + t.Description + "\n"
 		table += line
 	}
 

--- a/spamc_test.go
+++ b/spamc_test.go
@@ -267,6 +267,7 @@ func TestParseReport(t *testing.T) {
 				 0.4 INVALID_DATE           Invalid Date: header (not RFC 2822)
 				-0.0 NO_RELAYS              Informational: message was not relayed via SMTP
 				-1.2 MISSING_HEADERS        Missing To: header
+				 0.1 HEADER_FROM_DIFFERENT_DOMAINS From and EnvelopeFrom 2nd level mail are different
 			`),
 			Report{
 				Intro: normalizeSpace(`
@@ -296,6 +297,11 @@ func TestParseReport(t *testing.T) {
 						Points:      -1.2,
 						Rule:        "MISSING_HEADERS",
 						Description: "Missing To: header",
+					},
+					{
+						Points:      0.1,
+						Rule:        "HEADER_FROM_DIFFERENT_DOMAINS",
+						Description: "From and EnvelopeFrom 2nd level mail are different",
 					},
 				},
 			},


### PR DESCRIPTION
Would panic with:

    panic: strings: negative Repeat count